### PR TITLE
release 0.4.2: fix CI publish step + bump version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,18 +45,11 @@ jobs:
 
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag
-        uses: pypa/gh-action-pypi-publish@v1.10.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish --token ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish package on TestPyPI
         if: "! steps.check-version.outputs.tag"
-        uses: pypa/gh-action-pypi-publish@v1.10.0
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
+        run: uv publish --publish-url https://test.pypi.org/legacy/ --token ${{ secrets.TEST_PYPI_TOKEN }}
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v5.25.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-base"
-version = "0.4.1"
+version = "0.4.2"
 description = "Gridworks Base"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "gridworks-base"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "pika" },


### PR DESCRIPTION
Switch the release publish from pypa/gh-action-pypi-publish@v1.10.0 to `uv publish`. The pinned action's bundled twine cannot parse the Metadata-Version 2.4 that `uv build` now emits ("Metadata is missing required fields: Name, Version"), which is why the 0.4.0/0.4.1 CI releases failed and 0.4.0 had to be published by hand. uv handles 2.4 natively. Bump to 0.4.2 (0.4.1 was tagged but never reached PyPI).