### PR TITLE
gnr_ear_tx: the registry's scoped audit exchange (0.5.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,32 @@ This repo provides two things:
 2. **Dev-broker scripts** — run a local RabbitMQ broker for development
    (below).
 
+## How to commit changes
+
+Commits run pre-commit hooks (lint, format, and a drift-guard verifying the
+committed broker-definitions artifacts match `gwbase.topology`). To avoid
+surprises at commit time:
+
+```
+uv run pre-commit run --all-files   # every hook, before you commit
+./ci.sh                             # the full local gate: hooks + the test
+                                    # suite (needs the dev broker running —
+                                    # ./arm.sh or ./x86.sh)
+```
+
+If you changed `gwbase.topology`, regenerate the committed definitions
+artifacts first (the drift-guard will otherwise refuse the commit):
+
+```
+uv run python for_docker/gen_definitions.py --write-all --dir rabbit/rabbitconfig
+```
+
+Two gotchas the hooks have caught in the wild: run one hook alone with
+`uv run pre-commit run <hook-id> --all-files`; and if hooks fail with TLS
+errors reaching PyPI (`invalid peer certificate`), check for a stray
+`SSL_CERT_FILE` export in your shell — it replaces Python's trust bundle
+process-wide.
+
 ## Dev Rabbit Broker
 
 GridWorks services that use the AMQP transport require a running RabbitMQ

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-base"
-version = "0.5.6"
+version = "0.5.7"
 description = "Gridworks Base"
 readme = "README.md"
 authors = [

--- a/rabbit/rabbitconfig/dev_definitions.json
+++ b/rabbit/rabbitconfig/dev_definitions.json
@@ -162,6 +162,22 @@
     },
     {
       "arguments": {},
+      "destination": "gnr_ear_tx",
+      "destination_type": "exchange",
+      "routing_key": "#",
+      "source": "gnr_tx",
+      "vhost": "d1__1"
+    },
+    {
+      "arguments": {},
+      "destination": "gnr_ear_tx",
+      "destination_type": "exchange",
+      "routing_key": "#",
+      "source": "gnrmic_tx",
+      "vhost": "d1__1"
+    },
+    {
+      "arguments": {},
       "destination": "amq.topic",
       "destination_type": "exchange",
       "routing_key": "rjb.#",
@@ -184,6 +200,15 @@
       "durable": true,
       "internal": true,
       "name": "ear_tx",
+      "type": "topic",
+      "vhost": "d1__1"
+    },
+    {
+      "arguments": {},
+      "auto_delete": false,
+      "durable": true,
+      "internal": true,
+      "name": "gnr_ear_tx",
       "type": "topic",
       "vhost": "d1__1"
     },

--- a/rabbit/rabbitconfig/hybrid_definitions.json
+++ b/rabbit/rabbitconfig/hybrid_definitions.json
@@ -162,6 +162,22 @@
     },
     {
       "arguments": {},
+      "destination": "gnr_ear_tx",
+      "destination_type": "exchange",
+      "routing_key": "#",
+      "source": "gnr_tx",
+      "vhost": "hw1__1"
+    },
+    {
+      "arguments": {},
+      "destination": "gnr_ear_tx",
+      "destination_type": "exchange",
+      "routing_key": "#",
+      "source": "gnrmic_tx",
+      "vhost": "hw1__1"
+    },
+    {
+      "arguments": {},
       "destination": "amq.topic",
       "destination_type": "exchange",
       "routing_key": "rjb.#",
@@ -184,6 +200,15 @@
       "durable": true,
       "internal": true,
       "name": "ear_tx",
+      "type": "topic",
+      "vhost": "hw1__1"
+    },
+    {
+      "arguments": {},
+      "auto_delete": false,
+      "durable": true,
+      "internal": true,
+      "name": "gnr_ear_tx",
       "type": "topic",
       "vhost": "hw1__1"
     },

--- a/src/gwbase/topology.py
+++ b/src/gwbase/topology.py
@@ -51,6 +51,15 @@ EAR_EXCHANGE = "ear_tx"
 AMQP_TOPIC = "amq.topic"  # built-in; MQTT-bridged + wrapped (gw) traffic
 EAR_BINDING_KEY = "#"
 
+# The registry's SCOPED audit tap: a second, tiny ear fed only the
+# meaning-bearing registry slice — everything addressed to the registry (its
+# consume exchange) and everything the registry says (its publish exchange:
+# forest broadcasts AND the write verdicts, since every actor publishes via
+# its own mic — so refusals are witnessed too). The seed-store capture
+# consumes this with a plain `#`; the slice is defined HERE, in the fabric,
+# in git — never in a tap's runtime binding.
+GNR_EAR_EXCHANGE = "gnr_ear_tx"
+
 
 def consume_exchange(rc: RoutingClass) -> str:
     """Internal exchange an actor of class ``rc`` consumes from."""
@@ -98,7 +107,10 @@ def _amqp_classes_sorted() -> list[RoutingClass]:
 def exchanges() -> list[ExchangeSpec]:
     """Every exchange the broker must pre-provision, in a stable order:
     the ear tap, then a consume/publish pair per AMQP-actor class."""
-    specs: list[ExchangeSpec] = [ExchangeSpec(EAR_EXCHANGE, internal=True)]
+    specs: list[ExchangeSpec] = [
+        ExchangeSpec(EAR_EXCHANGE, internal=True),
+        ExchangeSpec(GNR_EAR_EXCHANGE, internal=True),
+    ]
     for rc in _amqp_classes_sorted():
         specs.append(ExchangeSpec(consume_exchange(rc), internal=True))
         specs.append(ExchangeSpec(publish_exchange(rc), internal=False))
@@ -119,6 +131,22 @@ def exchange_bindings() -> list[BindingSpec]:
             BindingSpec(publish_exchange(rc), EAR_EXCHANGE, EAR_BINDING_KEY)
         )
     bindings.append(BindingSpec(AMQP_TOPIC, EAR_EXCHANGE, EAR_BINDING_KEY))
+    # The registry's scoped audit slice (see GNR_EAR_EXCHANGE): to-gnr and
+    # from-gnr both fan in.
+    bindings.append(
+        BindingSpec(
+            consume_exchange(RoutingClass.GridNodeRegistry),
+            GNR_EAR_EXCHANGE,
+            EAR_BINDING_KEY,
+        )
+    )
+    bindings.append(
+        BindingSpec(
+            publish_exchange(RoutingClass.GridNodeRegistry),
+            GNR_EAR_EXCHANGE,
+            EAR_BINDING_KEY,
+        )
+    )
     # MQTT bridge tap: the time coordinator's BROADCASTS cross to the MQTT
     # plugin's exchange, so MQTT-native actors (scadas — reached via
     # amq.topic, see AMQP_ACTOR_CLASSES note) can subscribe to sim

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -42,11 +42,13 @@ def test_exchanges_cover_ear_plus_a_pair_per_class() -> None:
     specs = topo.exchanges()
     names = {s.name for s in specs}
     assert topo.EAR_EXCHANGE in names
-    # ear + 2 per AMQP class
-    assert len(specs) == 1 + 2 * len(topo.AMQP_ACTOR_CLASSES)
+    assert topo.GNR_EAR_EXCHANGE in names
+    # ear + the registry's scoped ear + 2 per AMQP class
+    assert len(specs) == 2 + 2 * len(topo.AMQP_ACTOR_CLASSES)
     by_name = {s.name: s for s in specs}
-    # ear_tx and every <rc>_tx are internal; every <rc>mic_tx is not
+    # ear_tx, gnr_ear_tx and every <rc>_tx are internal; every <rc>mic_tx is not
     assert by_name["ear_tx"].internal is True
+    assert by_name["gnr_ear_tx"].internal is True
     assert by_name["ltn_tx"].internal is True
     assert by_name["ltnmic_tx"].internal is False
     assert all(s.exchange_type == "topic" and s.durable for s in specs)
@@ -56,8 +58,20 @@ def test_bindings_cover_edges_and_ear_taps() -> None:
     bindings = topo.exchange_bindings()
     # one per routing edge, plus one ear tap per AMQP class, plus the
     # amq.topic ear tap, plus the timemic and gnrmic -> amq.topic MQTT
-    # bridge taps
-    assert len(bindings) == len(topo.ROUTING_EDGES) + len(topo.AMQP_ACTOR_CLASSES) + 3
+    # bridge taps, plus the registry's scoped ear pair (gnr_tx + gnrmic_tx
+    # -> gnr_ear_tx)
+    assert len(bindings) == len(topo.ROUTING_EDGES) + len(topo.AMQP_ACTOR_CLASSES) + 5
+    # the scoped ear hears everything said TO the registry and BY it
+    assert any(
+        b.source == "gnr_tx" and b.destination == "gnr_ear_tx" and b.routing_key == "#"
+        for b in bindings
+    )
+    assert any(
+        b.source == "gnrmic_tx"
+        and b.destination == "gnr_ear_tx"
+        and b.routing_key == "#"
+        for b in bindings
+    )
 
     # a known direct edge: ltnmic_tx -> super_tx on *.*.ltn.*.super.*
     assert any(

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ wheels = [
 
 [[package]]
 name = "gridworks-base"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "pika" },


### PR DESCRIPTION
Update the rabbit definitions to allow for the gnr ear to listen to all inbound/outbound traffic to the grid node registry, for storing in the seed persistent store (separate from the torrent of event stream messages)